### PR TITLE
Fixed link to Pipenv project

### DIFF
--- a/content/docs/get-started/install.md
+++ b/content/docs/get-started/install.md
@@ -26,7 +26,7 @@ brew install pipenv libyaml
 
 ### Linux setup
 
-1. Install (Pipenv)[https://pypi.org/project/pipenv/]
+1. Install [Pipenv](https://pypi.org/project/pipenv/)
 
 ## Create a Pipfile
 


### PR DESCRIPTION
This fixes the syntax of the link to the Pipenv project in the instructions for Linux.