### PR TITLE
Fix headers font size according to importance

### DIFF
--- a/source/sass/mixins/_type.sass
+++ b/source/sass/mixins/_type.sass
@@ -18,21 +18,21 @@
     margin-bottom: 30px
 
 =type-h2
-  font-size: 22px
+  font-size: 28px
   line-height: 1.14
   font-family: $font-heading
   +md
     font-size: 22px
 
 =type-h3
-  font-size: 20px
+  font-size: 24px
   line-height: 1.22
   font-family: $font-heading
   +md
     font-size: 20px
 
 =type-h4
-  font-size: 22px
+  font-size: 20px
   line-height: 28px
   font-family: $font-heading
   +md


### PR DESCRIPTION
This fixes the size of headers, as originally `h4` were bigger than `h3` making it hard to visually understand the structure of the document.

I also changed the size of the other headers scaling them with steps of 4 pixels: `h1` are 32px and the text is 16px, so I think it makes sense to have the following setup

* `h1` 32px
* `h2` 28px
* `h3` 24px
* `h4` 20px
* text 16px