### PR TITLE
Initial documentation of nested collections

### DIFF
--- a/content/docs/reference/collections.md
+++ b/content/docs/reference/collections.md
@@ -73,7 +73,7 @@ The `categories` key contains a list of categories that documents inside the col
 
 ## Nested collections
 
-You can create collections inside other collections simply creating a nested directory containing a blueprint
+You can create collections inside other collections simply creating a nested directory 
 
 ```bash
 ├─ /content*                     # All your content.
@@ -82,12 +82,10 @@ You can create collections inside other collections simply creating a nested dir
 |     ├─ /index.md               # A document belonging to "books".
 |     ├─ /contacts.md            # A document belonging to "books".
 |     └─ /how_to_use_grow        # The collection "how_to_use_grow".
-|        ├─ /_blueprint.yaml*    # The blueprint for "how_to_use_grow".
 |        ├─ /chapter01.md        # A document belonging to "how_to_use_grow".
 |        ├─ /chapter02.md        # A document belonging to "how_to_use_grow".
 |        ├─ /chapter03.md        # A document belonging to "how_to_use_grow".
 |     └─ /grow_style_guide       # The collection "grow_style_guide".
-|        ├─ /_blueprint.yaml*    # The blueprint for "grow_style_guide".
 |        ├─ /chapter01.md        # A document belonging to "grow_style_guide".
 |        ├─ /chapter02.md        # A document belonging to "grow_style_guide".
 ```
@@ -99,7 +97,23 @@ Inside the view used by `books/index.md` the variable `doc.collection.basename` 
 Anywhere in the pod you can refer to nested collections using their full basename, e.g.
 
 ``` jinja
-{% for chapter in g.collection('books/how_to_use_grow).list_docs() %}
+{% for chapter in g.collection('books/how_to_use_grow').list_docs() %}
 <a href="{{ chapter.url }}">{{ chapter.title }}</a>
 {% endfor %}
 ```
+
+Nested collections can be customised creating a blueprint file. This is optional, however, as the nested collection will use the blueprint file created for the parent collection.
+
+```bash
+├─ /content*
+|  ├─ /books
+|     ├─ /_blueprint.yaml*
+|     ├─ /index.md
+|     ├─ /contacts.md
+|     └─ /how_to_use_grow
+|        ├─ /_blueprint.yaml*    # This blueprint customises the collection
+|        ├─ /chapter01.md
+|        ├─ /chapter02.md
+|        ├─ /chapter03.md
+```
+

--- a/content/docs/reference/collections.md
+++ b/content/docs/reference/collections.md
@@ -11,7 +11,7 @@ Grow makes it easy to separate content from presentation, but ultimately leaves 
 
 ## Blueprints
 
-Every content collection must have a blueprint. Blueprints define how content is structured, displayed, and served. Blueprints are stored as YAML files in your pod's *content* directory.  For example, a blueprint for a collection "people" would be `/content/people/_blueprint.yaml`
+Every content collection must have a blueprint. Blueprints define how the content of a collection is structured, displayed, and served. Blueprints are stored as YAML files in your pod's *content* directory.  For example, the blueprint for a collection called `people` would be `/content/people/_blueprint.yaml` and might have the following content
 
 ```yaml
 path: /people/{slug}/              # The URL path format for content.
@@ -25,13 +25,13 @@ localization:                      # Overrides localization from podspec.yaml.
   - it
 ```
 
+The values in the blueprint are applied to all documents in the collection but can be overridden through the front matter of a document. See the documentation of the [front matter]([url('/content/docs/reference/documents.md')]#front-matter).
+
 ### path
 
-Specifies the URL path format for all content in this collection. Documents inherit the `path` specified in the blueprint. If `path` is omitted, content in this collection will not be generated into pages, unless a document specifies its own `$path`. If `path` is specified, `view` is a required field. [See a list of path formatters]([url('/content/docs/reference/urls.md')]#content-document-path-formatters).
+Specifies the URL path format for all content in this collection. If `path` is omitted, content in this collection will not be generated into pages, unless a document specifies its own `$path`. If `path` is specified, `view` is a required field.
 
-```yaml
-$path: /{root}/{base}/
-```
+Paths can be formatted in several ways, see the [list of path formatters]([url('/content/docs/reference/urls.md')]#content-document-path-formatters).
 
 ### view
 
@@ -70,3 +70,36 @@ $localization:
 ### categories
 
 The `categories` key contains a list of categories that documents inside the collection can fall into. A collection's categories can be used in conjunction with the `g.categories` template function to iterate over the documents in the collection, grouped by category.
+
+## Nested collections
+
+You can create collections inside other collections simply creating a nested directory containing a blueprint
+
+```bash
+├─ /content*                     # All your content.
+|  ├─ /books                     # The collection "books".
+|     ├─ /_blueprint.yaml*       # The blueprint for "books".
+|     ├─ /index.md               # A document belonging to "books".
+|     ├─ /contacts.md            # A document belonging to "books".
+|     └─ /how_to_use_grow        # The collection "how_to_use_grow".
+|        ├─ /_blueprint.yaml*    # The blueprint for "how_to_use_grow".
+|        ├─ /chapter01.md        # A document belonging to "how_to_use_grow".
+|        ├─ /chapter02.md        # A document belonging to "how_to_use_grow".
+|        ├─ /chapter03.md        # A document belonging to "how_to_use_grow".
+|     └─ /grow_style_guide       # The collection "grow_style_guide".
+|        ├─ /_blueprint.yaml*    # The blueprint for "grow_style_guide".
+|        ├─ /chapter01.md        # A document belonging to "grow_style_guide".
+|        ├─ /chapter02.md        # A document belonging to "grow_style_guide".
+```
+
+Here, `books` is a collection that contains documents, namely `index.md` and `contacts.md`. It also contains two nested collections, `books/how_to_use_grow` and `books/grow_style_guide`, each one with their own blueprint and content files.
+
+Inside the view used by `books/index.md` the variable `doc.collection.basename` will be `books`, while for `books/how_to_use_grow/chapter01.md` the value will be `books/how_to_use_grow`, and for `books/grow_style_guide/chapter01.md` it will be `books/grow_style_guide`.
+
+Anywhere in the pod you can refer to nested collections using their full basename, e.g.
+
+``` jinja
+{% for chapter in g.collection('books/how_to_use_grow).list_docs() %}
+<a href="{{ chapter.url }}">{{ chapter.title }}</a>
+{% endfor %}
+```


### PR DESCRIPTION
resolves #38 

This adds initial documentation for nested collections (as far as I understood them). It also reworks some of the text in the whole page to clarify and link to other pages.